### PR TITLE
renamed  session_id to lang as apparently it was supposed to be

### DIFF
--- a/ovos_stt_plugin_server/__init__.py
+++ b/ovos_stt_plugin_server/__init__.py
@@ -16,7 +16,7 @@ class OVOSHTTPServerSTT(STT):
     def execute(self, audio, language=None):
         self.response = requests.post(self.url, data=audio.get_wav_data(),
                                       headers={"Content-Type": "audio/wav"},
-                                      params={"session_id": language or self.lang})
+                                      params={"lang": language or self.lang})
         return self.response.text if self.response else None
 
 


### PR DESCRIPTION
session_id is used to pass language to the engine. renaming it to lang makes things clearer