### PR TITLE
Add neon endpoint to public servers

### DIFF
--- a/ovos_stt_plugin_server/__init__.py
+++ b/ovos_stt_plugin_server/__init__.py
@@ -25,7 +25,8 @@ class OVOSHTTPServerSTT(STT):
     def public_servers(self):
         return [
             "https://fasterwhisper.ziggyai.online/stt",
-            "https://stt.smartgic.io/fasterwhisper/stt"
+            "https://stt.smartgic.io/fasterwhisper/stt",
+            "https://whisper.neonaiservices.com/stt"
         ]
 
     @property


### PR DESCRIPTION
May require #19 if user agent filtering is implemented on the Neon endpoint (enabled by default in OPNSense nginx plugin)